### PR TITLE
Fix test run and deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,6 @@ rvm:
 addons:
   code_climate:
     repo_token: 8f697ca756250f0c2c54170ae27e8a9c459d18a0236903b11291c88291b3aac9
+
+after_success:
+  - bundle exec codeclimate-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ addons:
 
 language: ruby
 
+before_install: rvm rubygems master --force
+install: gem install --file
+script: "RUBYGEMS_GEMDEPS=- rake test"
+
 rvm:
 - "2.3.0"
 - "2.2"
@@ -14,6 +18,3 @@ rvm:
 addons:
   code_climate:
     repo_token: 8f697ca756250f0c2c54170ae27e8a9c459d18a0236903b11291c88291b3aac9
-
-after_success:
-  - bundle exec codeclimate-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ addons:
 
 language: ruby
 
-before_install: rvm rubygems master --force
 install: gem install --file
 script: "RUBYGEMS_GEMDEPS=- rake test"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ addons:
 
 language: ruby
 
-install: gem install --file
-script: "RUBYGEMS_GEMDEPS=- rake test"
-
 rvm:
 - "2.3.0"
 - "2.2"

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem "codeclimate-test-reporter", require: nil
+  gem "codeclimate-test-reporter", "< 1.0", require: nil
 end

--- a/test/integration/consumer_test.rb
+++ b/test/integration/consumer_test.rb
@@ -87,7 +87,7 @@ module Integration
       assert_equal 'POST', request.method
       assert_equal '/test', request.path
       assert_match(/key=value&oauth_consumer_key=consumer_key_86cad9&oauth_nonce=225579211881198842005988698334675835446&oauth_signature=26g7wHTtNO6ZWJaLltcueppHYiI%3[Dd]&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1199645624&oauth_token=token_411a7f&oauth_version=1.0/, request.body.split("&").sort.join("&"))
-      assert_equal nil, request['authorization']
+      assert_nil request['authorization']
     end
 
     def test_that_using_auth_headers_on_get_on_create_signed_requests_works
@@ -112,7 +112,7 @@ module Integration
       assert_equal 'POST', request.method
       assert_equal '/test', request.path
       assert_match(/key=value&oauth_consumer_key=consumer_key_86cad9&oauth_nonce=225579211881198842005988698334675835446&oauth_signature=26g7wHTtNO6ZWJaLltcueppHYiI%3[Dd]&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1199645624&oauth_token=token_411a7f&oauth_version=1.0/, request.body.split("&").sort.join("&"))
-      assert_equal nil, request['authorization']
+      assert_nil request['authorization']
     end
 
     def test_step_by_step_token_request
@@ -136,7 +136,7 @@ module Integration
       @consumer.sign!(request, nil,options)
 
       assert_equal 'GET', request.method
-      assert_equal nil, request.body
+      assert_nil request.body
       response=@consumer.http.request(request)
       assert_equal "200",response.code
       assert_equal "oauth_token=requestkey&oauth_token_secret=requestsecret",response.body

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 ENV['RACK_ENV'] = 'test'
 
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require "simplecov"
+SimpleCov.start
 
 require 'rubygems'
 require 'minitest/autorun'

--- a/test/units/test_net_http_client.rb
+++ b/test/units/test_net_http_client.rb
@@ -105,9 +105,9 @@ class NetHTTPClientTest < Minitest::Test
     assert_equal 'GET', request.method
     uri = URI.parse(request.path)
     assert_equal '/test', uri.path
-    assert_equal nil, uri.fragment
+    assert_nil uri.fragment
     assert_equal "key=value&oauth_consumer_key=consumer_key_86cad9&oauth_nonce=225579211881198842005988698334675835446&oauth_signature=1oO2izFav1GP4kEH2EskwXkCRFg%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1199645624&oauth_token=token_411a7f&oauth_version=1.0", uri.query.split("&").sort.join("&")
-    assert_equal nil, request['authorization']
+    assert_nil request['authorization']
   end
 
   def test_that_using_get_params_works_with_plaintext
@@ -117,9 +117,9 @@ class NetHTTPClientTest < Minitest::Test
     assert_equal 'GET', request.method
     uri = URI.parse(request.path)
     assert_equal '/test', uri.path
-    assert_equal nil, uri.fragment
+    assert_nil uri.fragment
     assert_equal "key=value&oauth_consumer_key=consumer_key_86cad9&oauth_nonce=225579211881198842005988698334675835446&oauth_signature=5888bf0345e5d237%263196ffd991c8ebdb&oauth_signature_method=PLAINTEXT&oauth_timestamp=1199645624&oauth_token=token_411a7f&oauth_version=1.0", uri.query.split("&").sort.join("&")
-    assert_equal nil, request['authorization']
+    assert_nil request['authorization']
   end
 
   def test_that_using_post_params_works
@@ -130,7 +130,7 @@ class NetHTTPClientTest < Minitest::Test
     assert_equal 'POST', request.method
     assert_equal '/test', request.path
     assert_match(/key=value&oauth_consumer_key=consumer_key_86cad9&oauth_nonce=225579211881198842005988698334675835446&oauth_signature=26g7wHTtNO6ZWJaLltcueppHYiI%3[Dd]&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1199645624&oauth_token=token_411a7f&oauth_version=1.0/, request.body.split("&").sort.join("&"))
-    assert_equal nil, request['authorization']
+    assert_nil request['authorization']
   end
 
   def test_that_using_post_params_works_with_plaintext
@@ -141,7 +141,7 @@ class NetHTTPClientTest < Minitest::Test
     assert_equal 'POST', request.method
     assert_equal '/test', request.path
     assert_equal "key=value&oauth_consumer_key=consumer_key_86cad9&oauth_nonce=225579211881198842005988698334675835446&oauth_signature=5888bf0345e5d237%263196ffd991c8ebdb&oauth_signature_method=PLAINTEXT&oauth_timestamp=1199645624&oauth_token=token_411a7f&oauth_version=1.0", request.body.split("&").sort.join("&")
-    assert_equal nil, request['authorization']
+    assert_nil request['authorization']
   end
 
   def test_that_using_post_body_works
@@ -153,7 +153,7 @@ class NetHTTPClientTest < Minitest::Test
     assert_equal 'POST', request.method
     assert_equal '/test', request.path
     assert_match(/OAuth oauth_consumer_key="consumer_key_86cad9", oauth_nonce="225579211881198842005988698334675835446", oauth_signature="%2[fF]DMMBOJzQ6JmEaXlAXDLGtD1z2I%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1199645624", oauth_token="token_411a7f", oauth_version="1.0"/, request['authorization'].split("&").sort.join("&"))
-    # assert_equal nil, request['authorization']
+    # assert_nil request['authorization']
   end
 
   def test_that_using_post_with_uri_params_works
@@ -164,10 +164,10 @@ class NetHTTPClientTest < Minitest::Test
     assert_equal 'POST', request.method
     uri = URI.parse(request.path)
     assert_equal '/test', uri.path
-    assert_equal nil, uri.fragment
+    assert_nil uri.fragment
     assert_equal "key=value&oauth_consumer_key=consumer_key_86cad9&oauth_nonce=225579211881198842005988698334675835446&oauth_signature=26g7wHTtNO6ZWJaLltcueppHYiI%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1199645624&oauth_token=token_411a7f&oauth_version=1.0", uri.query.split("&").sort.join('&')
     assert_equal "", request.body
-    assert_equal nil, request['authorization']
+    assert_nil request['authorization']
   end
 
   def test_that_using_post_with_uri_and_form_params_works
@@ -178,10 +178,10 @@ class NetHTTPClientTest < Minitest::Test
     assert_equal 'POST', request.method
     uri = URI.parse(request.path)
     assert_equal '/test', uri.path
-    assert_equal nil, uri.fragment
+    assert_nil uri.fragment
     assert_equal "key=value&oauth_consumer_key=consumer_key_86cad9&oauth_nonce=225579211881198842005988698334675835446&oauth_signature=4kSU8Zd1blWo3W6qJH7eaRTMkg0%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1199645624&oauth_token=token_411a7f&oauth_version=1.0", uri.query.split("&").sort.join('&')
     assert_equal "key2=value2", request.body
-    assert_equal nil, request['authorization']
+    assert_nil request['authorization']
   end
 
   def test_that_using_post_with_uri_and_data_works
@@ -193,11 +193,11 @@ class NetHTTPClientTest < Minitest::Test
     assert_equal 'POST', request.method
     uri = URI.parse(request.path)
     assert_equal '/test', uri.path
-    assert_equal nil, uri.fragment
+    assert_nil uri.fragment
     assert_equal "data", request.body
     assert_equal 'text/ascii', request.content_type
     assert_equal "key=value&oauth_body_hash=oXyaqmHoChv3HQ2FCvTluqmAC70%3D&oauth_consumer_key=consumer_key_86cad9&oauth_nonce=225579211881198842005988698334675835446&oauth_signature=MHRKU42iVHU4Ke9kBUDa9Zw6IAM%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1199645624&oauth_token=token_411a7f&oauth_version=1.0", uri.query.split("&").sort.join('&')
-    assert_equal nil, request['authorization']
+    assert_nil request['authorization']
   end
 
 


### PR DESCRIPTION
`rake test` failed with the following error:
```
W, [2017-03-19T08:04:17.060025 #39975]  WARN -- :       This usage of the Code Climate Test Reporter is now deprecated. Since version
      1.0, we now require you to run `SimpleCov` in your test/spec helper, and then
      run the provided `codeclimate-test-reporter` binary separately to report your
      results to Code Climate.

      More information here: https://github.com/codeclimate/ruby-test-reporter/blob/master/README.md
```

- Followed instructions for setting up codeclimate for v1.
- Also addressed deprecation warnings `Use assert_nil if expecting nil from ...`